### PR TITLE
Enable package validation to track public API compatibility

### DIFF
--- a/src/PureQL.CSharp.Model.Serialization/PureQL.CSharp.Model.Serialization.csproj
+++ b/src/PureQL.CSharp.Model.Serialization/PureQL.CSharp.Model.Serialization.csproj
@@ -5,6 +5,8 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsAotCompatible>false</IsAotCompatible>
+    <EnablePackageValidation>true</EnablePackageValidation>
+    <PackageValidationBaselineVersion>0.1.0-preview.2.0.0</PackageValidationBaselineVersion>
   </PropertyGroup>
   <PropertyGroup>
     <PackageId>PureQL.CSharp.Model.Serialization</PackageId>


### PR DESCRIPTION
Closes #12

Add `EnablePackageValidation` and `PackageValidationBaselineVersion` to the project file so that breaking public API changes are detected during build/pack before publishing.