### PR TITLE
Deserialize joins from the spec-mandated "joins" property

### DIFF
--- a/src/PureQL.CSharp.Model.Serialization/QueryConverter.cs
+++ b/src/PureQL.CSharp.Model.Serialization/QueryConverter.cs
@@ -28,7 +28,7 @@ internal sealed record QueryJsonModel
         FromExpression from,
         IEnumerable<SelectExpression> select,
         OneOf<BooleanReturning, BooleanArrayReturning>? where,
-        IEnumerable<Join>? join,
+        IEnumerable<Join>? joins,
         IEnumerable<Field>? groupBy,
         BooleanReturning? having,
         IEnumerable<OrderByItem>? orderBy,
@@ -39,7 +39,7 @@ internal sealed record QueryJsonModel
         From = from ?? throw new JsonException();
         Select = select ?? throw new JsonException();
         Where = where;
-        Join = join;
+        Joins = joins;
         GroupBy = groupBy;
         Having = having;
         OrderBy = orderBy;
@@ -55,7 +55,7 @@ internal sealed record QueryJsonModel
     public OneOf<BooleanReturning, BooleanArrayReturning>? Where { get; }
 
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    public IEnumerable<Join>? Join { get; }
+    public IEnumerable<Join>? Joins { get; }
 
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public IEnumerable<Field>? GroupBy { get; }
@@ -90,7 +90,7 @@ internal sealed class QueryConverter : JsonConverter<Query>
             model.From,
             model.Select,
             model.Where,
-            model.Join,
+            model.Joins,
             model.GroupBy,
             model.Having,
             model.OrderBy,

--- a/src/Tests/PureQL.CSharp.Model.Serialization.Tests/QueryConverterTests.cs
+++ b/src/Tests/PureQL.CSharp.Model.Serialization.Tests/QueryConverterTests.cs
@@ -2,6 +2,8 @@ using System.Text.Json;
 using System.Text.Json.Serialization;
 using PureQL.CSharp.Model.ArrayReturnings;
 using PureQL.CSharp.Model.Fields;
+using PureQL.CSharp.Model.Returnings;
+using PureQL.CSharp.Model.Scalars;
 
 namespace PureQL.CSharp.Model.Serialization.Tests;
 
@@ -229,6 +231,128 @@ public sealed record QueryConverterTests
                         )
                     ),
                 ]
+            ),
+            _options
+        );
+
+        Assert.Equal(expected, output);
+    }
+
+    [Fact]
+    public void ReadJoinsCase()
+    {
+        const string expectedEntity = "erfhduibgn";
+        const string expectedJoinEntity = "refnhbdjusi";
+        const string expectedField = "edrfghiujn";
+
+        const string input = /*lang=json,strict*/
+            $$"""
+            {
+              "from": {
+                "entity": "{{expectedEntity}}"
+              },
+              "select": [
+                {
+                  "entity": "{{expectedEntity}}",
+                  "field": "{{expectedField}}",
+                  "type": {
+                    "name": "string"
+                  }
+                }
+              ],
+              "joins": [
+                {
+                  "type": "inner",
+                  "entity": "{{expectedJoinEntity}}",
+                  "on": {
+                    "type": {
+                      "name": "boolean"
+                    },
+                    "value": true
+                  }
+                }
+              ]
+            }
+            """;
+
+        Query query = JsonSerializer.Deserialize<Query>(input, _options)!;
+
+        Assert.NotNull(query.Join);
+        Assert.True(
+            Enumerable
+                .Empty<Join>()
+                .Append(
+                    new Join(
+                        JoinType.Inner,
+                        expectedJoinEntity,
+                        new BooleanReturning(new BooleanScalar(true))
+                    )
+                )
+                .SequenceEqual(query.Join!)
+        );
+    }
+
+    [Fact]
+    public void WriteJoinsCase()
+    {
+        const string expectedEntity = "erfhduibgn";
+        const string expectedJoinEntity = "refnhbdjusi";
+        const string expectedField = "edrfghiujn";
+
+        const string expected = /*lang=json,strict*/
+            $$"""
+            {
+              "from": {
+                "entity": "{{expectedEntity}}"
+              },
+              "select": [
+                {
+                  "entity": "{{expectedEntity}}",
+                  "field": "{{expectedField}}",
+                  "type": {
+                    "name": "string"
+                  }
+                }
+              ],
+              "joins": [
+                {
+                  "type": "inner",
+                  "entity": "{{expectedJoinEntity}}",
+                  "on": {
+                    "type": {
+                      "name": "boolean"
+                    },
+                    "value": true
+                  }
+                }
+              ]
+            }
+            """;
+
+        string output = JsonSerializer.Serialize(
+            new Query(
+                new FromExpression(expectedEntity),
+                [
+                    new SelectExpression(
+                        new ArrayReturning(
+                            new StringArrayReturning(
+                                new StringField(expectedEntity, expectedField)
+                            )
+                        )
+                    ),
+                ],
+                where: null,
+                [
+                    new Join(
+                        JoinType.Inner,
+                        expectedJoinEntity,
+                        new BooleanReturning(new BooleanScalar(true))
+                    ),
+                ],
+                groupBy: null,
+                having: null,
+                orderBy: null,
+                pagination: null
             ),
             _options
         );


### PR DESCRIPTION
## Problem

`QueryJsonModel`'s `[JsonConstructor]` bound the join list from a parameter named `join`, but the PureQL specification names this property `joins` (see the spec's query schema and `samples/05_joins.json` in kudima03/PureQL-Specification). System.Text.Json silently ignores unknown JSON properties by default, so every spec-compliant query with a `joins` array deserialized with `Query.Join == null` — no exception, no warning.

Downstream in Pure.RelationalSchema.Storage.PureQL.Projection this produced two distinct-looking symptoms that are actually the same root cause:

- **Silent no-op join** (kudima03/Pure.RelationalSchema.Storage.PureQL.Projection#92): with `Query.Join` null, the JOIN pipeline stage is skipped entirely, so an inner join's `on` condition never filters anything — the base table's rows pass through unchanged regardless of whether the condition could ever match.
- **Joined-column select rejected** (kudima03/Pure.RelationalSchema.Storage.PureQL.Projection#91): `EntityReferenceValidator` builds its set of known entities from `From`, `From.Alias`, and `Query.Join`. With `Join` null, a `select` referencing the joined table's exact `schema.table` entity — the syntax the validator's own error message recommends — is rejected as unknown.

I confirmed this by deserializing the exact payloads from both issues against the current `main`: the `joins` array parses without error (200-shaped success), but `query.Join` is null in both cases, exactly matching the reported behavior.

## Fix

Rename the `[JsonConstructor]` parameter (and the mirrored `QueryJsonModel` property) from `join`/`Join` to `joins`/`Joins`, on both the read and write paths. `[JsonConstructor]` parameter names are the wire property names (case-insensitive), so this is the complete fix — no naming-policy attribute needed.

**Breaking change:** the legacy `join` spelling was never spec-valid and is no longer accepted. Consumers sending `join` (there don't appear to be any conforming ones, since the spec always said `joins`) need to switch to `joins`.

## Tests

Added `ReadJoinsCase` / `WriteJoinsCase` to `QueryConverterTests`, round-tripping a query with one inner join through both directions. Full suite: 5751 passed, 0 failed. `dotnet format --verify-no-changes` clean.

## Related

- Closes kudima03/Pure.RelationalSchema.Storage.PureQL.Projection#91
- Closes kudima03/Pure.RelationalSchema.Storage.PureQL.Projection#92
- Regression coverage for the translator side (proving the AST-level behavior is correct once `Query.Join` is populated) is in kudima03/Pure.RelationalSchema.Storage.PureQL.Projection#live-issue-90-91-92-repro

🤖 Generated with [Claude Code](https://claude.com/claude-code)