### PR TITLE
Update package validation baseline to 0.1.0-preview.3.0.0

### DIFF
--- a/src/PureQL.CSharp.Model.Serialization/PureQL.CSharp.Model.Serialization.csproj
+++ b/src/PureQL.CSharp.Model.Serialization/PureQL.CSharp.Model.Serialization.csproj
@@ -6,7 +6,7 @@
     <Nullable>enable</Nullable>
     <IsAotCompatible>false</IsAotCompatible>
     <EnablePackageValidation>true</EnablePackageValidation>
-    <PackageValidationBaselineVersion>0.1.0-preview.2.0.1</PackageValidationBaselineVersion>
+    <PackageValidationBaselineVersion>0.1.0-preview.3.0.0</PackageValidationBaselineVersion>
   </PropertyGroup>
   <PropertyGroup>
     <PackageId>PureQL.CSharp.Model.Serialization</PackageId>


### PR DESCRIPTION
Bump `PackageValidationBaselineVersion` from `0.1.0-preview.2.0.1` to `0.1.0-preview.3.0.0` following the successful publish.