### PR TITLE
Replace TryPick chains with Switch in converter Write methods

### DIFF
--- a/src/PureQL.CSharp.Model.Serialization/ArrayEqualities/ArrayEqualityConverter.cs
+++ b/src/PureQL.CSharp.Model.Serialization/ArrayEqualities/ArrayEqualityConverter.cs
@@ -66,37 +66,14 @@ internal sealed class ArrayEqualityConverter : JsonConverter<ArrayEquality>
         JsonSerializerOptions options
     )
     {
-        if (value.TryPickT0(out BooleanArrayEquality? booleanArray, out _))
-        {
-            JsonSerializer.Serialize(writer, booleanArray, options);
-        }
-        else if (value.TryPickT1(out DateArrayEquality? dateArray, out _))
-        {
-            JsonSerializer.Serialize(writer, dateArray, options);
-        }
-        else if (value.TryPickT2(out DateTimeArrayEquality? dateTimeArray, out _))
-        {
-            JsonSerializer.Serialize(writer, dateTimeArray, options);
-        }
-        else if (value.TryPickT3(out NumberArrayEquality? numberArray, out _))
-        {
-            JsonSerializer.Serialize(writer, numberArray, options);
-        }
-        else if (value.TryPickT4(out StringArrayEquality? stringArray, out _))
-        {
-            JsonSerializer.Serialize(writer, stringArray, options);
-        }
-        else if (value.TryPickT5(out TimeArrayEquality? timeArray, out _))
-        {
-            JsonSerializer.Serialize(writer, timeArray, options);
-        }
-        else if (value.TryPickT6(out UuidArrayEquality? uuidArray, out _))
-        {
-            JsonSerializer.Serialize(writer, uuidArray, options);
-        }
-        else
-        {
-            throw new JsonException("Unable to determine ArrayEquality type.");
-        }
+        value.Switch(
+            booleanArray => JsonSerializer.Serialize(writer, booleanArray, options),
+            dateArray => JsonSerializer.Serialize(writer, dateArray, options),
+            dateTimeArray => JsonSerializer.Serialize(writer, dateTimeArray, options),
+            numberArray => JsonSerializer.Serialize(writer, numberArray, options),
+            stringArray => JsonSerializer.Serialize(writer, stringArray, options),
+            timeArray => JsonSerializer.Serialize(writer, timeArray, options),
+            uuidArray => JsonSerializer.Serialize(writer, uuidArray, options)
+        );
     }
 }

--- a/src/PureQL.CSharp.Model.Serialization/ArrayReturnings/ArrayReturningConverter.cs
+++ b/src/PureQL.CSharp.Model.Serialization/ArrayReturnings/ArrayReturningConverter.cs
@@ -66,37 +66,14 @@ internal sealed class ArrayReturningConverter : JsonConverter<ArrayReturning>
         JsonSerializerOptions options
     )
     {
-        if (value.TryPickT0(out BooleanArrayReturning? booleanArray, out _))
-        {
-            JsonSerializer.Serialize(writer, booleanArray, options);
-        }
-        else if (value.TryPickT1(out DateArrayReturning? dateArray, out _))
-        {
-            JsonSerializer.Serialize(writer, dateArray, options);
-        }
-        else if (value.TryPickT2(out DateTimeArrayReturning? dateTimeArray, out _))
-        {
-            JsonSerializer.Serialize(writer, dateTimeArray, options);
-        }
-        else if (value.TryPickT3(out NumberArrayReturning? numberArray, out _))
-        {
-            JsonSerializer.Serialize(writer, numberArray, options);
-        }
-        else if (value.TryPickT4(out StringArrayReturning? stringArray, out _))
-        {
-            JsonSerializer.Serialize(writer, stringArray, options);
-        }
-        else if (value.TryPickT5(out TimeArrayReturning? timeArray, out _))
-        {
-            JsonSerializer.Serialize(writer, timeArray, options);
-        }
-        else if (value.TryPickT6(out UuidArrayReturning? uuidArray, out _))
-        {
-            JsonSerializer.Serialize(writer, uuidArray, options);
-        }
-        else
-        {
-            throw new JsonException("Unable to determine ArrayReturning type.");
-        }
+        value.Switch(
+            booleanArray => JsonSerializer.Serialize(writer, booleanArray, options),
+            dateArray => JsonSerializer.Serialize(writer, dateArray, options),
+            dateTimeArray => JsonSerializer.Serialize(writer, dateTimeArray, options),
+            numberArray => JsonSerializer.Serialize(writer, numberArray, options),
+            stringArray => JsonSerializer.Serialize(writer, stringArray, options),
+            timeArray => JsonSerializer.Serialize(writer, timeArray, options),
+            uuidArray => JsonSerializer.Serialize(writer, uuidArray, options)
+        );
     }
 }

--- a/src/PureQL.CSharp.Model.Serialization/ArrayReturnings/BooleanArrayReturningConverter.cs
+++ b/src/PureQL.CSharp.Model.Serialization/ArrayReturnings/BooleanArrayReturningConverter.cs
@@ -61,43 +61,15 @@ internal sealed class BooleanArrayReturningConverter
         JsonSerializerOptions options
     )
     {
-        if (value.TryPickT0(out BooleanArrayScalar? scalar, out _))
-        {
-            JsonSerializer.Serialize<IBooleanArrayScalar>(writer, scalar, options);
-        }
-        else if (value.TryPickT1(out BooleanField? field, out _))
-        {
-            JsonSerializer.Serialize(writer, field, options);
-        }
-        else if (value.TryPickT2(out BooleanArrayParameter? parameter, out _))
-        {
-            JsonSerializer.Serialize(writer, parameter, options);
-        }
-        else if (value.TryPickT3(out EachComparison? comparison, out _))
-        {
-            JsonSerializer.Serialize(writer, comparison, options);
-        }
-        else if (value.TryPickT4(out EachEquality? equality, out _))
-        {
-            JsonSerializer.Serialize(writer, equality, options);
-        }
-        else if (value.TryPickT5(out EachAndOperator? andOp, out _))
-        {
-            JsonSerializer.Serialize(writer, andOp, options);
-        }
-        else if (value.TryPickT6(out EachOrOperator? orOp, out _))
-        {
-            JsonSerializer.Serialize(writer, orOp, options);
-        }
-        else if (value.TryPickT7(out EachNotOperator? notOp, out _))
-        {
-            JsonSerializer.Serialize(writer, notOp, options);
-        }
-        else
-        {
-            throw new JsonException(
-                "Unable to determine BooleanArrayReturning type."
-            );
-        }
+        value.Switch(
+            scalar => JsonSerializer.Serialize<IBooleanArrayScalar>(writer, scalar, options),
+            field => JsonSerializer.Serialize(writer, field, options),
+            parameter => JsonSerializer.Serialize(writer, parameter, options),
+            comparison => JsonSerializer.Serialize(writer, comparison, options),
+            equality => JsonSerializer.Serialize(writer, equality, options),
+            andOp => JsonSerializer.Serialize(writer, andOp, options),
+            orOp => JsonSerializer.Serialize(writer, orOp, options),
+            notOp => JsonSerializer.Serialize(writer, notOp, options)
+        );
     }
 }

--- a/src/PureQL.CSharp.Model.Serialization/ArrayReturnings/DateArrayReturningConverter.cs
+++ b/src/PureQL.CSharp.Model.Serialization/ArrayReturnings/DateArrayReturningConverter.cs
@@ -44,25 +44,11 @@ internal sealed class DateArrayReturningConverter : JsonConverter<DateArrayRetur
         JsonSerializerOptions options
     )
     {
-        if (value.TryPickT0(out DateArrayParameter? parameter, out _))
-        {
-            JsonSerializer.Serialize(writer, parameter, options);
-        }
-        else if (value.TryPickT1(out DateField? field, out _))
-        {
-            JsonSerializer.Serialize(writer, field, options);
-        }
-        else if (value.TryPickT2(out DateArrayScalar? scalar, out _))
-        {
-            JsonSerializer.Serialize<IDateArrayScalar>(writer, scalar, options);
-        }
-        else if (value.TryPickT3(out EachDateAddDays? addDays, out _))
-        {
-            JsonSerializer.Serialize(writer, addDays, options);
-        }
-        else
-        {
-            throw new JsonException("Unable to determine DateArrayReturning type.");
-        }
+        value.Switch(
+            parameter => JsonSerializer.Serialize(writer, parameter, options),
+            field => JsonSerializer.Serialize(writer, field, options),
+            scalar => JsonSerializer.Serialize<IDateArrayScalar>(writer, scalar, options),
+            addDays => JsonSerializer.Serialize(writer, addDays, options)
+        );
     }
 }

--- a/src/PureQL.CSharp.Model.Serialization/ArrayReturnings/DateTimeArrayReturningConverter.cs
+++ b/src/PureQL.CSharp.Model.Serialization/ArrayReturnings/DateTimeArrayReturningConverter.cs
@@ -51,27 +51,12 @@ internal sealed class DateTimeArrayReturningConverter
         JsonSerializerOptions options
     )
     {
-        if (value.TryPickT0(out DateTimeArrayParameter? parameter, out _))
-        {
-            JsonSerializer.Serialize(writer, parameter, options);
-        }
-        else if (value.TryPickT1(out DateTimeField? field, out _))
-        {
-            JsonSerializer.Serialize(writer, field, options);
-        }
-        else if (value.TryPickT2(out DateTimeArrayScalar? scalar, out _))
-        {
-            JsonSerializer.Serialize<IDateTimeArrayScalar>(writer, scalar, options);
-        }
-        else if (value.TryPickT3(out EachDateTimeAddSeconds? addSeconds, out _))
-        {
-            JsonSerializer.Serialize(writer, addSeconds, options);
-        }
-        else
-        {
-            throw new JsonException(
-                "Unable to determine DateTimeArrayReturning type."
-            );
-        }
+        value.Switch(
+            parameter => JsonSerializer.Serialize(writer, parameter, options),
+            field => JsonSerializer.Serialize(writer, field, options),
+            scalar =>
+                JsonSerializer.Serialize<IDateTimeArrayScalar>(writer, scalar, options),
+            addSeconds => JsonSerializer.Serialize(writer, addSeconds, options)
+        );
     }
 }

--- a/src/PureQL.CSharp.Model.Serialization/ArrayReturnings/NumberArrayReturningConverter.cs
+++ b/src/PureQL.CSharp.Model.Serialization/ArrayReturnings/NumberArrayReturningConverter.cs
@@ -67,39 +67,14 @@ internal sealed class NumberArrayReturningConverter : JsonConverter<NumberArrayR
         JsonSerializerOptions options
     )
     {
-        if (value.TryPickT0(out NumberArrayParameter? parameter, out _))
-        {
-            JsonSerializer.Serialize(writer, parameter, options);
-        }
-        else if (value.TryPickT1(out NumberField? field, out _))
-        {
-            JsonSerializer.Serialize(writer, field, options);
-        }
-        else if (value.TryPickT2(out NumberArrayScalar? scalar, out _))
-        {
-            JsonSerializer.Serialize<INumberArrayScalar>(writer, scalar, options);
-        }
-        else if (value.TryPickT3(out EachArithmetic? arithmetic, out _))
-        {
-            JsonSerializer.Serialize(writer, arithmetic, options);
-        }
-        else if (value.TryPickT4(out EachDateDiffDays? dateDiff, out _))
-        {
-            JsonSerializer.Serialize(writer, dateDiff, options);
-        }
-        else if (value.TryPickT5(out EachDateTimeDiffSeconds? dateTimeDiff, out _))
-        {
-            JsonSerializer.Serialize(writer, dateTimeDiff, options);
-        }
-        else if (value.TryPickT6(out EachTimeDiffSeconds? timeDiff, out _))
-        {
-            JsonSerializer.Serialize(writer, timeDiff, options);
-        }
-        else
-        {
-            throw new JsonException(
-                "Unable to determine NumberArrayReturning type."
-            );
-        }
+        value.Switch(
+            parameter => JsonSerializer.Serialize(writer, parameter, options),
+            field => JsonSerializer.Serialize(writer, field, options),
+            scalar => JsonSerializer.Serialize<INumberArrayScalar>(writer, scalar, options),
+            arithmetic => JsonSerializer.Serialize(writer, arithmetic, options),
+            dateDiff => JsonSerializer.Serialize(writer, dateDiff, options),
+            dateTimeDiff => JsonSerializer.Serialize(writer, dateTimeDiff, options),
+            timeDiff => JsonSerializer.Serialize(writer, timeDiff, options)
+        );
     }
 }

--- a/src/PureQL.CSharp.Model.Serialization/ArrayReturnings/StringArrayReturningConverter.cs
+++ b/src/PureQL.CSharp.Model.Serialization/ArrayReturnings/StringArrayReturningConverter.cs
@@ -37,21 +37,10 @@ internal sealed class StringArrayReturningConverter : JsonConverter<StringArrayR
         JsonSerializerOptions options
     )
     {
-        if (value.TryPickT0(out StringArrayParameter? parameter, out _))
-        {
-            JsonSerializer.Serialize(writer, parameter, options);
-        }
-        else if (value.TryPickT1(out StringField? field, out _))
-        {
-            JsonSerializer.Serialize(writer, field, options);
-        }
-        else if (value.TryPickT2(out StringArrayScalar? scalar, out _))
-        {
-            JsonSerializer.Serialize<IStringArrayScalar>(writer, scalar, options);
-        }
-        else
-        {
-            throw new JsonException("Unable to determine StringArrayReturning type.");
-        }
+        value.Switch(
+            parameter => JsonSerializer.Serialize(writer, parameter, options),
+            field => JsonSerializer.Serialize(writer, field, options),
+            scalar => JsonSerializer.Serialize<IStringArrayScalar>(writer, scalar, options)
+        );
     }
 }

--- a/src/PureQL.CSharp.Model.Serialization/ArrayReturnings/TimeArrayReturningConverter.cs
+++ b/src/PureQL.CSharp.Model.Serialization/ArrayReturnings/TimeArrayReturningConverter.cs
@@ -44,25 +44,11 @@ internal sealed class TimeArrayReturningConverter : JsonConverter<TimeArrayRetur
         JsonSerializerOptions options
     )
     {
-        if (value.TryPickT0(out TimeArrayParameter? parameter, out _))
-        {
-            JsonSerializer.Serialize(writer, parameter, options);
-        }
-        else if (value.TryPickT1(out TimeField? field, out _))
-        {
-            JsonSerializer.Serialize(writer, field, options);
-        }
-        else if (value.TryPickT2(out TimeArrayScalar? scalar, out _))
-        {
-            JsonSerializer.Serialize<ITimeArrayScalar>(writer, scalar, options);
-        }
-        else if (value.TryPickT3(out EachTimeAddSeconds? addSeconds, out _))
-        {
-            JsonSerializer.Serialize(writer, addSeconds, options);
-        }
-        else
-        {
-            throw new JsonException("Unable to determine TimeArrayReturning type.");
-        }
+        value.Switch(
+            parameter => JsonSerializer.Serialize(writer, parameter, options),
+            field => JsonSerializer.Serialize(writer, field, options),
+            scalar => JsonSerializer.Serialize<ITimeArrayScalar>(writer, scalar, options),
+            addSeconds => JsonSerializer.Serialize(writer, addSeconds, options)
+        );
     }
 }

--- a/src/PureQL.CSharp.Model.Serialization/ArrayReturnings/UuidArrayReturningConverter.cs
+++ b/src/PureQL.CSharp.Model.Serialization/ArrayReturnings/UuidArrayReturningConverter.cs
@@ -37,21 +37,10 @@ internal sealed class UuidArrayReturningConverter : JsonConverter<UuidArrayRetur
         JsonSerializerOptions options
     )
     {
-        if (value.TryPickT0(out UuidArrayParameter? parameter, out _))
-        {
-            JsonSerializer.Serialize(writer, parameter, options);
-        }
-        else if (value.TryPickT1(out UuidField? field, out _))
-        {
-            JsonSerializer.Serialize(writer, field, options);
-        }
-        else if (value.TryPickT2(out UuidArrayScalar? scalar, out _))
-        {
-            JsonSerializer.Serialize<IUuidArrayScalar>(writer, scalar, options);
-        }
-        else
-        {
-            throw new JsonException("Unable to determine UuidArrayReturning type.");
-        }
+        value.Switch(
+            parameter => JsonSerializer.Serialize(writer, parameter, options),
+            field => JsonSerializer.Serialize(writer, field, options),
+            scalar => JsonSerializer.Serialize<IUuidArrayScalar>(writer, scalar, options)
+        );
     }
 }

--- a/src/PureQL.CSharp.Model.Serialization/BooleanOperations/BooleanOperatorArgumentsConverter.cs
+++ b/src/PureQL.CSharp.Model.Serialization/BooleanOperations/BooleanOperatorArgumentsConverter.cs
@@ -45,17 +45,9 @@ internal sealed class BooleanOperatorArgumentsConverter
         JsonSerializerOptions options
     )
     {
-        if (value.TryPickT0(out IEnumerable<BooleanReturning>? returnings, out _))
-        {
-            JsonSerializer.Serialize(writer, returnings, options);
-        }
-        else if (value.TryPickT1(out BooleanArrayReturning? booleanArray, out _))
-        {
-            JsonSerializer.Serialize(writer, booleanArray, options);
-        }
-        else
-        {
-            throw new JsonException("Unable to determine BooleanOperatorArguments type.");
-        }
+        value.Switch(
+            returnings => JsonSerializer.Serialize(writer, returnings, options),
+            booleanArray => JsonSerializer.Serialize(writer, booleanArray, options)
+        );
     }
 }

--- a/src/PureQL.CSharp.Model.Serialization/BooleanOperations/BooleanOrArrayReturningConverter.cs
+++ b/src/PureQL.CSharp.Model.Serialization/BooleanOperations/BooleanOrArrayReturningConverter.cs
@@ -41,19 +41,9 @@ internal sealed class BooleanOrArrayReturningConverter
         JsonSerializerOptions options
     )
     {
-        if (value.TryPickT0(out BooleanReturning? booleanReturning, out _))
-        {
-            JsonSerializer.Serialize(writer, booleanReturning, options);
-        }
-        else if (value.TryPickT1(out BooleanArrayReturning? booleanArray, out _))
-        {
-            JsonSerializer.Serialize(writer, booleanArray, options);
-        }
-        else
-        {
-            throw new JsonException(
-                "Unable to determine BooleanOrArrayReturning type."
-            );
-        }
+        value.Switch(
+            booleanReturning => JsonSerializer.Serialize(writer, booleanReturning, options),
+            booleanArray => JsonSerializer.Serialize(writer, booleanArray, options)
+        );
     }
 }

--- a/src/PureQL.CSharp.Model.Serialization/EachEqualities/EachEqualityRightConverters.cs
+++ b/src/PureQL.CSharp.Model.Serialization/EachEqualities/EachEqualityRightConverters.cs
@@ -41,18 +41,10 @@ internal sealed class NumberReturningOrArrayConverter
         JsonSerializerOptions options
     )
     {
-        if (value.TryPickT0(out NumberReturning? single, out _))
-        {
-            JsonSerializer.Serialize(writer, single, options);
-        }
-        else if (value.TryPickT1(out NumberArrayReturning? array, out _))
-        {
-            JsonSerializer.Serialize(writer, array, options);
-        }
-        else
-        {
-            throw new JsonException("Unable to determine NumberReturningOrArray type.");
-        }
+        value.Switch(
+            single => JsonSerializer.Serialize(writer, single, options),
+            array => JsonSerializer.Serialize(writer, array, options)
+        );
     }
 }
 
@@ -91,18 +83,10 @@ internal sealed class StringReturningOrArrayConverter
         JsonSerializerOptions options
     )
     {
-        if (value.TryPickT0(out StringReturning? single, out _))
-        {
-            JsonSerializer.Serialize(writer, single, options);
-        }
-        else if (value.TryPickT1(out StringArrayReturning? array, out _))
-        {
-            JsonSerializer.Serialize(writer, array, options);
-        }
-        else
-        {
-            throw new JsonException("Unable to determine StringReturningOrArray type.");
-        }
+        value.Switch(
+            single => JsonSerializer.Serialize(writer, single, options),
+            array => JsonSerializer.Serialize(writer, array, options)
+        );
     }
 }
 
@@ -141,18 +125,10 @@ internal sealed class DateReturningOrArrayConverter
         JsonSerializerOptions options
     )
     {
-        if (value.TryPickT0(out DateReturning? single, out _))
-        {
-            JsonSerializer.Serialize(writer, single, options);
-        }
-        else if (value.TryPickT1(out DateArrayReturning? array, out _))
-        {
-            JsonSerializer.Serialize(writer, array, options);
-        }
-        else
-        {
-            throw new JsonException("Unable to determine DateReturningOrArray type.");
-        }
+        value.Switch(
+            single => JsonSerializer.Serialize(writer, single, options),
+            array => JsonSerializer.Serialize(writer, array, options)
+        );
     }
 }
 
@@ -191,18 +167,10 @@ internal sealed class TimeReturningOrArrayConverter
         JsonSerializerOptions options
     )
     {
-        if (value.TryPickT0(out TimeReturning? single, out _))
-        {
-            JsonSerializer.Serialize(writer, single, options);
-        }
-        else if (value.TryPickT1(out TimeArrayReturning? array, out _))
-        {
-            JsonSerializer.Serialize(writer, array, options);
-        }
-        else
-        {
-            throw new JsonException("Unable to determine TimeReturningOrArray type.");
-        }
+        value.Switch(
+            single => JsonSerializer.Serialize(writer, single, options),
+            array => JsonSerializer.Serialize(writer, array, options)
+        );
     }
 }
 
@@ -241,20 +209,10 @@ internal sealed class DateTimeReturningOrArrayConverter
         JsonSerializerOptions options
     )
     {
-        if (value.TryPickT0(out DateTimeReturning? single, out _))
-        {
-            JsonSerializer.Serialize(writer, single, options);
-        }
-        else if (value.TryPickT1(out DateTimeArrayReturning? array, out _))
-        {
-            JsonSerializer.Serialize(writer, array, options);
-        }
-        else
-        {
-            throw new JsonException(
-                "Unable to determine DateTimeReturningOrArray type."
-            );
-        }
+        value.Switch(
+            single => JsonSerializer.Serialize(writer, single, options),
+            array => JsonSerializer.Serialize(writer, array, options)
+        );
     }
 }
 
@@ -293,17 +251,9 @@ internal sealed class UuidReturningOrArrayConverter
         JsonSerializerOptions options
     )
     {
-        if (value.TryPickT0(out UuidReturning? single, out _))
-        {
-            JsonSerializer.Serialize(writer, single, options);
-        }
-        else if (value.TryPickT1(out UuidArrayReturning? array, out _))
-        {
-            JsonSerializer.Serialize(writer, array, options);
-        }
-        else
-        {
-            throw new JsonException("Unable to determine UuidReturningOrArray type.");
-        }
+        value.Switch(
+            single => JsonSerializer.Serialize(writer, single, options),
+            array => JsonSerializer.Serialize(writer, array, options)
+        );
     }
 }

--- a/src/PureQL.CSharp.Model.Serialization/EqualityConverter.cs
+++ b/src/PureQL.CSharp.Model.Serialization/EqualityConverter.cs
@@ -33,17 +33,9 @@ internal sealed class EqualityConverter : JsonConverter<Equality>
         JsonSerializerOptions options
     )
     {
-        if (value.TryPickT0(out SingleValueEquality? single, out _))
-        {
-            JsonSerializer.Serialize(writer, single, options);
-        }
-        else if (value.TryPickT1(out ArrayEquality? array, out _))
-        {
-            JsonSerializer.Serialize(writer, array, options);
-        }
-        else
-        {
-            throw new JsonException("Unable to determine Equality type.");
-        }
+        value.Switch(
+            single => JsonSerializer.Serialize(writer, single, options),
+            array => JsonSerializer.Serialize(writer, array, options)
+        );
     }
 }

--- a/src/PureQL.CSharp.Model.Serialization/Returnings/NumberReturningConverter.cs
+++ b/src/PureQL.CSharp.Model.Serialization/Returnings/NumberReturningConverter.cs
@@ -51,29 +51,12 @@ internal sealed class NumberReturningConverter : JsonConverter<NumberReturning>
         JsonSerializerOptions options
     )
     {
-        if (value.TryPickT0(out NumberParameter? parameter, out _))
-        {
-            JsonSerializer.Serialize(writer, parameter, options);
-        }
-        else if (value.TryPickT1(out NumberScalar? scalar, out _))
-        {
-            JsonSerializer.Serialize<INumberScalar>(writer, scalar, options);
-        }
-        else if (value.TryPickT2(out Arithmetic? arithmetic, out _))
-        {
-            JsonSerializer.Serialize(writer, arithmetic, options);
-        }
-        else if (value.TryPickT3(out NumberAggregate? numberAgg, out _))
-        {
-            JsonSerializer.Serialize(writer, numberAgg, options);
-        }
-        else if (value.TryPickT4(out Count? count, out _))
-        {
-            JsonSerializer.Serialize(writer, count, options);
-        }
-        else
-        {
-            throw new JsonException("Unable to determine NumberReturning type.");
-        }
+        value.Switch(
+            parameter => JsonSerializer.Serialize(writer, parameter, options),
+            scalar => JsonSerializer.Serialize<INumberScalar>(writer, scalar, options),
+            arithmetic => JsonSerializer.Serialize(writer, arithmetic, options),
+            numberAgg => JsonSerializer.Serialize(writer, numberAgg, options),
+            count => JsonSerializer.Serialize(writer, count, options)
+        );
     }
 }

--- a/src/PureQL.CSharp.Model.Serialization/Returnings/SingleValueReturningConverter.cs
+++ b/src/PureQL.CSharp.Model.Serialization/Returnings/SingleValueReturningConverter.cs
@@ -46,37 +46,14 @@ internal sealed class SingleValueReturningConverter : JsonConverter<SingleValueR
         JsonSerializerOptions options
     )
     {
-        if (value.TryPickT0(out BooleanReturning? boolean, out _))
-        {
-            JsonSerializer.Serialize(writer, boolean, options);
-        }
-        else if (value.TryPickT1(out DateReturning? date, out _))
-        {
-            JsonSerializer.Serialize(writer, date, options);
-        }
-        else if (value.TryPickT2(out DateTimeReturning? dateTime, out _))
-        {
-            JsonSerializer.Serialize(writer, dateTime, options);
-        }
-        else if (value.TryPickT3(out NumberReturning? number, out _))
-        {
-            JsonSerializer.Serialize(writer, number, options);
-        }
-        else if (value.TryPickT4(out StringReturning? stringValue, out _))
-        {
-            JsonSerializer.Serialize(writer, stringValue, options);
-        }
-        else if (value.TryPickT5(out TimeReturning? time, out _))
-        {
-            JsonSerializer.Serialize(writer, time, options);
-        }
-        else if (value.TryPickT6(out UuidReturning? uuid, out _))
-        {
-            JsonSerializer.Serialize(writer, uuid, options);
-        }
-        else
-        {
-            throw new JsonException("Unable to determine SingleValueReturning type.");
-        }
+        value.Switch(
+            boolean => JsonSerializer.Serialize(writer, boolean, options),
+            date => JsonSerializer.Serialize(writer, date, options),
+            dateTime => JsonSerializer.Serialize(writer, dateTime, options),
+            number => JsonSerializer.Serialize(writer, number, options),
+            stringValue => JsonSerializer.Serialize(writer, stringValue, options),
+            time => JsonSerializer.Serialize(writer, time, options),
+            uuid => JsonSerializer.Serialize(writer, uuid, options)
+        );
     }
 }

--- a/src/PureQL.CSharp.Model.Serialization/Returnings/StringReturningConverter.cs
+++ b/src/PureQL.CSharp.Model.Serialization/Returnings/StringReturningConverter.cs
@@ -41,21 +41,10 @@ internal sealed class StringReturningConverter : JsonConverter<StringReturning>
         JsonSerializerOptions options
     )
     {
-        if (value.TryPickT0(out StringParameter? parameter, out _))
-        {
-            JsonSerializer.Serialize(writer, parameter, options);
-        }
-        else if (value.TryPickT1(out StringScalar? scalar, out _))
-        {
-            JsonSerializer.Serialize<IStringScalar>(writer, scalar, options);
-        }
-        else if (value.TryPickT2(out StringAggregate? aggregate, out _))
-        {
-            JsonSerializer.Serialize(writer, aggregate, options);
-        }
-        else
-        {
-            throw new JsonException("Unable to determine StringReturning type.");
-        }
+        value.Switch(
+            parameter => JsonSerializer.Serialize(writer, parameter, options),
+            scalar => JsonSerializer.Serialize<IStringScalar>(writer, scalar, options),
+            aggregate => JsonSerializer.Serialize(writer, aggregate, options)
+        );
     }
 }

--- a/src/PureQL.CSharp.Model.Serialization/Returnings/TimeReturningConverter.cs
+++ b/src/PureQL.CSharp.Model.Serialization/Returnings/TimeReturningConverter.cs
@@ -37,21 +37,10 @@ internal sealed class TimeReturningConverter : JsonConverter<TimeReturning>
         JsonSerializerOptions options
     )
     {
-        if (value.TryPickT0(out TimeParameter? parameter, out _))
-        {
-            JsonSerializer.Serialize(writer, parameter, options);
-        }
-        else if (value.TryPickT1(out TimeScalar? scalar, out _))
-        {
-            JsonSerializer.Serialize<ITimeScalar>(writer, scalar, options);
-        }
-        else if (value.TryPickT2(out TimeAggregate? aggregate, out _))
-        {
-            JsonSerializer.Serialize(writer, aggregate, options);
-        }
-        else
-        {
-            throw new JsonException("Unable to determine TimeReturning type.");
-        }
+        value.Switch(
+            parameter => JsonSerializer.Serialize(writer, parameter, options),
+            scalar => JsonSerializer.Serialize<ITimeScalar>(writer, scalar, options),
+            aggregate => JsonSerializer.Serialize(writer, aggregate, options)
+        );
     }
 }

--- a/src/PureQL.CSharp.Model.Serialization/Returnings/UuidReturningConverter.cs
+++ b/src/PureQL.CSharp.Model.Serialization/Returnings/UuidReturningConverter.cs
@@ -30,17 +30,9 @@ internal sealed class UuidReturningConverter : JsonConverter<UuidReturning>
         JsonSerializerOptions options
     )
     {
-        if (value.TryPickT0(out UuidParameter? parameter, out _))
-        {
-            JsonSerializer.Serialize(writer, parameter, options);
-        }
-        else if (value.TryPickT1(out UuidScalar? scalar, out _))
-        {
-            JsonSerializer.Serialize<IUuidScalar>(writer, scalar, options);
-        }
-        else
-        {
-            throw new JsonException("Unable to determine UuidReturning type.");
-        }
+        value.Switch(
+            parameter => JsonSerializer.Serialize(writer, parameter, options),
+            scalar => JsonSerializer.Serialize<IUuidScalar>(writer, scalar, options)
+        );
     }
 }


### PR DESCRIPTION
## Summary
- Replaces `TryPickTN(...)` chains (`if / else if / else throw`) with `OneOf`/`OneOfBase.Switch(...)` in every converter `Write` method where the chain only selects a single serialization branch.
- Left `Read` methods that use `TryPick` inside ternary expressions to build a returned value untouched (`JoinConverter`, `AndOperatorConverter`, `OrOperatorConverter`), since `Switch` returns `void` and doesn't fit that shape.

Closes #53

## Test plan
- [x] `dotnet build --no-restore -warnaserror` — passes
- [x] `dotnet format --verify-no-changes` — clean
- [x] `dotnet test --no-build` — 5961/5961 tests pass (same count as before the change)